### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
 
     steps:
       - uses: actions/checkout@v7
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
 
     steps:
       - uses: actions/checkout@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "click>=8.1.7,<9.0.0",


### PR DESCRIPTION
Add Python 3.14 to the supported versions.

## Changes
- CI: add `3.14` to the `test` and `mypy` job matrices
- `pyproject.toml`: add the `Programming Language :: Python :: 3.14` classifier

`requires-python` stays `>=3.10` (no lower-bound change).

## Verification
Ran locally under Python 3.14.5:
- `pytest` — 14 passed
- `mypy` (strict) — no issues in 16 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)