### PR TITLE
Use PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # required for PyPI Trusted Publishing (OIDC)
     steps:
       - name: Dump GitHub context
         env:
@@ -34,8 +36,6 @@ jobs:
         run: python -m build
       - name: Publish
         uses: pypa/gh-action-pypi-publish@v1.14.0
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
       - name: Dump GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}


### PR DESCRIPTION
Switch the publish workflow to PyPI Trusted Publishing (OIDC).

## Changes
- Remove `password: ${{ secrets.PYPI_API_TOKEN }}` from the publish step
- Add `permissions: id-token: write` to the `publish` job

PyPI Trusted Publisher already configured for this repo/workflow. This also re-enables build attestations, which were disabled while an explicit password was set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)